### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/Issuespot-team/1ca090c3-ba3e-491d-8d47-b60a6d5cb8ce/a222dac0-64dc-4374-b54c-6c92c628d2c6/_apis/work/boardbadge/28c21fed-8a19-4146-a3dc-2a371e90b90e)](https://dev.azure.com/Issuespot-team/1ca090c3-ba3e-491d-8d47-b60a6d5cb8ce/_boards/board/t/a222dac0-64dc-4374-b54c-6c92c628d2c6/Microsoft.RequirementCategory)
 # issuess


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/Issuespot-team/1ca090c3-ba3e-491d-8d47-b60a6d5cb8ce/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.